### PR TITLE
Add support for SSE 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ echo $(pwd)/.venv
       "args": [
         "run",
         "--directory",
-        "/path/to/mcp-server-jupyter/src/mcp_server_jupyter",
+        "/Users/inna/mcp-server-jupyter/src/mcp_server_jupyter",
         "mcp-server-jupyter"
       ],
       "env": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "nbclient>=0.10.2",
     "nbformat>=5.10.4",
     "pillow>=11.0.0",
+    "starlette>=0.36.0",
+    "uvicorn>=0.27.0",
 ]
 
 [tool.pyright]

--- a/src/mcp_server_jupyter/server.py
+++ b/src/mcp_server_jupyter/server.py
@@ -297,7 +297,9 @@ async def run(transport_type="stdio", port=8000):
     elif transport_type == "sse":
         import uvicorn
 
-        uvicorn.run(starlette_app, host="127.0.0.1", port=port)
+        config = uvicorn.Config(starlette_app, host="127.0.0.1", port=port)
+        uvicorn_server = uvicorn.Server(config)
+        await uvicorn_server.serve()
 
 
 def main():

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ cli = [
 
 [[package]]
 name = "mcp-server-jupyter"
-version = "0.1.1"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "ipykernel" },
@@ -441,6 +441,8 @@ dependencies = [
     { name = "nbclient" },
     { name = "nbformat" },
     { name = "pillow" },
+    { name = "starlette" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
@@ -456,6 +458,8 @@ requires-dist = [
     { name = "nbclient", specifier = ">=0.10.2" },
     { name = "nbformat", specifier = ">=5.10.4" },
     { name = "pillow", specifier = ">=11.0.0" },
+    { name = "starlette", specifier = ">=0.36.0" },
+    { name = "uvicorn", specifier = ">=0.27.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Adding support for SSE transport. It will be used in the Julyter plugin. 

To start in with SSE transport:
```
uv run --directory /Users/inna/mcp-server-jupyter/src/mcp_server_jupyter mcp-server-jupyter sse --port 3001
```

<img width="906" alt="image" src="https://github.com/user-attachments/assets/28791f09-08d5-4555-8834-201a899af9e9" />
